### PR TITLE
Bugfix; Multiple db instance creation

### DIFF
--- a/src/db/dbConnection.ts
+++ b/src/db/dbConnection.ts
@@ -5,7 +5,7 @@ import errorEnums from "../constants/errorConstants"
 import successEnums from "../constants/successConstant"
 
 const logger = loggerManager.getLogger();
-class Database {
+export class Database {
   private readonly sequelize: Sequelize;
 
   constructor() {
@@ -42,4 +42,5 @@ class Database {
 
 }
 
-export default Database;
+const database = new Database();
+export default database;

--- a/src/model/courseModel.ts
+++ b/src/model/courseModel.ts
@@ -1,7 +1,5 @@
 import { DataTypes, Model } from "sequelize"
-import Database from "../db/dbConnection"
-
-const database = new Database();
+import database from "../db/dbConnection"
 
 class Course extends Model { };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import loggerManager from "./utility/logger"
 import router from "./routes/courseRoutes"
 import loginrouter from "./routes/loginRoute"
 import webRouter from "./routes/webRoute"
-import Database from "./db/dbConnection"
+import database, { Database } from "./db/dbConnection"
 import errorEnums from "./constants/errorConstants"
 
 class Server {
@@ -20,7 +20,7 @@ class Server {
     this.PORT = port.PORT;
     this.logger = loggerManager.getLogger();
     this.app = express();
-    this.database = new Database();
+    this.database = database;
   }
 
   async start() {


### PR DESCRIPTION
Previously, we exported the **Database** class from **dbconnection.ts** and instantiated two instances: one in **server.ts** and another in **courseModel.ts**. The database credentials were provided to **server.ts**, resulting in only the instance in **server.ts** being connected to the database. Consequently, the instance in **courseModel.ts** was unable to create tables in the database.

To address this issue, we have made a modification. Now, we are exporting a _single instance_ from **dbconnection.ts**, ensuring that the same instance is utilized consistently throughout the codebase. This change resolves the connectivity problem and ensures that both s**erver.ts** and **courseModel.ts** share the same connected instance of the database.